### PR TITLE
use 'accept-language-parser' to parse locale from request header,

### DIFF
--- a/lib/languageLoader.js
+++ b/lib/languageLoader.js
@@ -3,6 +3,7 @@ var GetTextSprintf = require('./getTextSprintf');
 var readL10nFiles = require('./readL10nFiles');
 var localeNames = require('./localeNames');
 var normalizeLocaleCode = require('./normalizeLocaleCode');
+var acceptHeaderParser = require('accept-language-parser');
 
 var languageCache = {};
 var localeCodes = [];
@@ -77,22 +78,39 @@ module.exports.getLocaleCodes = function () {
 // "en-US,en;q=0.8,zh-TW;q=0.6,zh;q=0.4,zh-CN;q=0.2";
 module.exports.getHeaderLocale = function (headerValue) {
 	if (!headerValue) return;
-
-	var preferredLanguage = headerValue.split(',').map(function (localePref) {
-		var a = localePref.split(';');
-		return {
-			locale: a[0].toLowerCase(),
-			q: parseFloat((a[1] || 'q=1.0').split('=').pop())
-		};
-	}).sort(function (pref1, pref2) { // sort by q rank desc
-		if (pref1.q < pref2.q) return 1;
-		if (pref1.q > pref2.q) return -1;
-		return 0;
-	}).filter(function (pref) { // limit to supported languages
-		return ~localeCodes.indexOf(pref.locale);
-	}).shift(); // chose the best available
-
-	return preferredLanguage ? preferredLanguage.locale : null;
+	
+	var bestMatch = {
+	  code: null,
+	  region: null
+	};
+	
+	acceptLanguages = acceptHeaderParser.parse( headerValue );
+	acceptLanguages.forEach(function(acceptLanguage) {
+	  if ( bestMatch.code && bestMatch.region ) {
+	    return;
+	  }
+	  code = acceptLanguage.code.toLowerCase();
+	  if ( bestMatch.code && bestMatch.code !== code ) {
+	    return;
+	  }
+	  if ( acceptLanguage.region ) {
+	    region = acceptLanguage.region.toLowerCase();
+	    if ( localeCodes.indexOf( code + "-" + region ) !== -1 ) {
+	      bestMatch.code = code;
+	      bestMatch.region = region;
+	      return;
+	    }
+	  }
+	  if ( !bestMatch.code && localeCodes.indexOf( code ) !== -1 ) {
+	    bestMatch.code = code;
+	  }
+  });
+	
+	if ( !bestMatch.code ) {
+	  return null;
+	}
+	
+	return bestMatch.region ? bestMatch.code + "-" + bestMatch.region : bestMatch.code;
 };
 
 // used by tests currently

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hapi-l10n-gettext",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"description": "A hapijs plug-in for l10n via gettext",
 	"main": "lib/index.js",
 	"scripts": {
@@ -30,7 +30,8 @@
 		"hoek": "^2.4.1",
 		"node-gettext": "^0.2.14",
 		"recursive-readdir": "^1.2.0",
-		"sprintf-js": "0.0.7"
+		"sprintf-js": "0.0.7",
+    "accept-language-parser": "^1.0.2"
 	},
 	"devDependencies": {
 		"tape": "^2.14.0"

--- a/tests/fixtures/locales/de-de.po
+++ b/tests/fixtures/locales/de-de.po
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+"Language: de-de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "Register"
+msgstr "Registrieren"
+
+msgid "Email"
+msgstr "E-Mail"
+
+msgid "Password"
+msgstr "Passwort"
+
+msgid "Confirm Password"
+msgstr "Passwort bestätigen"
+
+msgid "First Name"
+msgstr "Vorname"
+
+msgid "Last Name"
+msgstr "Nachname"

--- a/tests/languageLoaderTests.js
+++ b/tests/languageLoaderTests.js
@@ -8,7 +8,7 @@ test("setup returns locales found in PO files (and language names from language-
 
 	t.test("Tests", function(t) {
 		var localeCodes = languageLoader.getLocaleCodes();
-		[ 'de', 'en', 'es', 'fr', 'it', 'ja', 'pt-br', 'zh-cn', 'zh-tw' ].forEach(function(locale) {
+		[ 'de', 'de-de', 'en', 'es', 'fr', 'it', 'ja', 'pt-br', 'zh-cn', 'zh-tw' ].forEach(function(locale) {
 			t.ok(~localeCodes.indexOf(locale), "Found " + locale);
 		});
 		t.end();
@@ -26,6 +26,10 @@ test("getHeaderLocale can parse a complex accept-language header value", functio
 		var selectedLanguage = languageLoader.getHeaderLocale(headerValue);
 		t.equal(selectedLanguage, expected, "If the user's first choice is supported, it will be returned.");
 
+    headerValue = "no,nl;q=0.8";
+    selectedLanguage = languageLoader.getHeaderLocale(headerValue);
+    t.equal(selectedLanguage, null, "If users choice is not supported, return null (to set default locale).");
+
 		headerValue = "test0,test1;q=0.8,zh-CN;q=0.6,en-US;q=0.4,en;q=0.2";
 		expected = 'zh-cn';
 		selectedLanguage = languageLoader.getHeaderLocale(headerValue);
@@ -35,6 +39,21 @@ test("getHeaderLocale can parse a complex accept-language header value", functio
 		expected = 'zh-tw';
 		selectedLanguage = languageLoader.getHeaderLocale(headerValue);
 		t.equal(selectedLanguage, expected, "If only the user's last choice is supported, it will be returned.");
+
+    headerValue = "de-AT,en;q=0.8";
+    expected = 'de';
+    selectedLanguage = languageLoader.getHeaderLocale(headerValue);
+    t.equal(selectedLanguage, expected, "If only the users first choice dialect is not supported, return users first choice base language.");
+
+    headerValue = "de-DE,de;q=0.8,en;q=0.6";
+    expected = 'de-de';
+    selectedLanguage = languageLoader.getHeaderLocale(headerValue);
+    t.equal(selectedLanguage, expected, "If users first choice dialect is supprted, return dialect.");
+
+    headerValue = "de-AT,de-DE;q=0.8,en;q=0.6";
+    expected = 'de-de';
+    selectedLanguage = languageLoader.getHeaderLocale(headerValue);
+    t.equal(selectedLanguage, expected, "If users first choice dialect is not supported, but second choice dialect matches with same language, return second choice dialect instead of base language.");
 
 		t.end();
 	});


### PR DESCRIPTION
fallback to base language of first choice (if available) if the requested dialect is not available